### PR TITLE
feat: lookup host ip if none given

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,52 @@
 given an ip address, return which cloud provider it belongs to (EC2, GCE, etc)
 
 ```sh
-> which-cloud 104.196.27.39
-> gce
+$ which-cloud 104.196.27.39
+gce
+```
+
+if no ip is given, `which-cloud` will use the public ip of the current host
+
+```sh
+$ which-cloud
+AT&T Internet Services (SIS-80)
 ```
 
 ## Installing
 
+### CLI
+
 ```sh
 npm i which-cloud -g
 ```
+
+```sh
+which-cloud
+```
+
+### Module
+
+```sh
+npm i which-cloud --save
+```
+
+```js
+const whichCloud = require('which-cloud')
+```
+
+## API
+
+### `whichCloud([ip,] callback)`
+
+- `ip`: string, optional
+
+    Determine the cloud provider for this ip
+
+    If no ip is given, the public ip of the current host will be used
+
+- `callback`: function, required
+
+    Called with an `Error` or the determined cloud provider as a string
 
 ## Supported Clouds
 

--- a/bin/which-cloud.js
+++ b/bin/which-cloud.js
@@ -2,14 +2,12 @@
 
 const which = require('../')
 const argv = require('yargs')
-  .usage('$0 <ip>')
+  .usage('$0 [ip]')
   .help()
   .alias('help', 'h')
-  .demand(1, 'you must provide an ip to lookup')
   .argv
-const ip = argv._[0]
 
-which(ip, function (err, cloud) {
+function cb (err, cloud) {
   if (err) {
     console.log(which.default)
     process.exit(1)
@@ -17,4 +15,7 @@ which(ip, function (err, cloud) {
     console.log(cloud)
     process.exit(0)
   }
-})
+}
+
+if (argv._.length) which(argv._[0], cb)
+else which(cb)

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "gce-ips": "^1.0.2",
     "ip-range-check": "0.0.1",
     "lodash.assign": "^4.0.9",
+    "public-ip": "^1.2.0",
     "request": "^2.72.0",
     "whois": "^2.1.6",
     "xml2js": "^0.4.16",

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,13 +1,15 @@
 /* global describe, it */
 
-require('chai').should()
+const should = require('chai').should()
 
 const exec = require('child_process').exec
 
 describe('cli', function () {
-  it('displays help if no ip is provided', function (done) {
+  it('looks up host ip if no ip is provided', function (done) {
     exec('./bin/which-cloud.js', function (err, stdout, stderr) {
-      err.message.should.match(/you must provide an ip to lookup/)
+      should.not.exist(err)
+      stderr.should.be.empty
+      stdout.should.be.ok
       return done()
     })
   })


### PR DESCRIPTION
Fixes #13.

Adds `public-ip@1.2.0` as a dependency in order to lookup the public IP of the current host if no IP is given. Cannot use `public-ip` greater than version 1 if we want to preserve Node 0.10 compatibility.

Changes API to make the `ip` arg optional, allowing just a callback to be given to perform the public IP lookup before determining cloud.

Changes CLI to allow no args. This could be considered a breaking change since output and exit code will be different. However, since it's adding functionality rather than taking it away, we can probably just consider this a feature.
